### PR TITLE
Fixing bug with vite and imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+            "import": "./dist/index.js"
 		}
 	},
 	"peerDependencies": {


### PR DESCRIPTION
I was getting the following error:

```
[vite] (ssr) Error when evaluating SSR module /src/routes/+layout.svelte: Failed to resolve entry for package "convex-svelte". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "convex-svelte" package
```

which was resolved by adding a line to package.json